### PR TITLE
Swift 4.2 migration

### DIFF
--- a/AKMaskField.xcodeproj/project.pbxproj
+++ b/AKMaskField.xcodeproj/project.pbxproj
@@ -212,11 +212,12 @@
 				TargetAttributes = {
 					010F96091DF2BFB000321C94 = {
 						CreatedOnToolsVersion = 8.1;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Manual;
 					};
 					01959A151DF1BA7700C9E359 = {
 						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -342,7 +343,8 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -374,7 +376,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -398,7 +401,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.artemkrachulov.AKMaskFieldExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -421,7 +425,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.artemkrachulov.AKMaskFieldExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/AKMaskField/AKMaskField.swift
+++ b/AKMaskField/AKMaskField.swift
@@ -106,7 +106,7 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
                         index : y,
                         blockIndex : i,
                         status : .clear,
-                        pattern : pattern,
+                        pattern : pattern ?? AKMaskFieldPatternCharacter.AnyChar,
                         patternRange : patternRange,
                         template : maskTemplateDefault,
                         templateRange : templateRange))
@@ -158,10 +158,10 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
             var copy: Bool = true
             var _maskTemplate = String(maskTemplateDefault)
             
-            if maskTemplate.characters.count == maskExpression!.characters.count - (maskBlocks.count * 2) {
+            if maskTemplate.count == maskExpression!.count - (maskBlocks.count * 2) {
                 copy = false
                 _maskTemplate = maskTemplate
-            } else if maskTemplate.characters.count == 1 {
+            } else if maskTemplate.count == 1 {
                 _maskTemplate = maskTemplate
             }
             
@@ -217,7 +217,7 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
                 return
             }
             
-            _ = textField(self, shouldChangeCharactersIn: NSMakeRange(0, maskText.characters.count), replacementString: text ?? "")
+            _ = textField(self, shouldChangeCharactersIn: NSMakeRange(0, maskText.count), replacementString: text ?? "")
         }
     }
     
@@ -378,7 +378,7 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
         switch maskStatus {
         case .clear       : position = maskBlocks.first!.templateRange.location
         case .incomplete  : position = maskBlocks.flatMap { $0.chars.filter { $0.status == .clear } }.first!.templateRange.location
-        case .complete    : position = maskBlocks.last!.templateRange.toRange()!.upperBound
+        case .complete    : position = Range(maskBlocks.last!.templateRange)!.upperBound
         }
         
         AKMaskFieldUtility.maskField(self, moveCaretToPosition: position)
@@ -457,8 +457,8 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
         var location      = range.location
         var savedLocation = range.location
         
-        for replacementCharacter in string.characters {
-            if location == maskText?.characters.count { break }
+        for replacementCharacter in string {
+            if location == maskText?.count { break }
             
             // Find next character
             // If character outside the block, jump to first character of the next block
@@ -545,7 +545,7 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
                         // Start carret position
                         var _location = _range.location
                         
-                        for replacementCharacter in _string.characters {
+                        for replacementCharacter in _string {
                             if _location > maskBlocks[i].templateRange.length { break }
                             
                             if matchTextCharacter(replacementCharacter, withMaskCharacter: maskBlocks[i].chars[_location]) {
@@ -566,7 +566,7 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
 
                     if !_string.isEmpty {
                         
-                        var maskTextRange = NSMakeRange(_range.location, _string.characters.count)
+                        var maskTextRange = NSMakeRange(_range.location, _string.count)
                         
                         // Object
                         
@@ -587,7 +587,7 @@ open class AKMaskField: UITextField, UITextFieldDelegate  {
                         
                         
                         // New carret position
-                        location = maskTextRange.toRange()!.upperBound
+                        location = Range(maskTextRange)!.upperBound
                         
                         event = .insert
                         

--- a/AKMaskField/AKMaskFieldBlockCharacter.swift
+++ b/AKMaskField/AKMaskFieldBlockCharacter.swift
@@ -31,7 +31,7 @@ public struct AKMaskFieldBlockCharacter {
     
     /// The mask pattern character.
     
-    public var pattern: AKMaskFieldPatternCharacter!
+    public var pattern: AKMaskFieldPatternCharacter
     
     /// Location of the pattern character in the mask.
     
@@ -41,7 +41,7 @@ public struct AKMaskFieldBlockCharacter {
     
     /// The mask template character.
     
-    public var template: Character!
+    public var template: Character
     
     /// Location of the mask template character in the mask template.
     

--- a/AKMaskField/AKMaskFieldUtility.swift
+++ b/AKMaskField/AKMaskFieldUtility.swift
@@ -39,7 +39,7 @@ public class AKMaskFieldUtility {
         guard let sourceString = sourceString else {
             return ""
         }
-        return sourceString.substring(with: rangeFromString(sourceString, nsRange: range))
+        return String(sourceString[rangeFromString(sourceString, nsRange: range)])
     }
     
     public class func replace(_ sourceString: inout String!, withString string: String, inRange range: NSRange) {
@@ -61,7 +61,7 @@ public class AKMaskFieldUtility {
     public class func matchesInString(_ string: String, pattern: String) -> [NSTextCheckingResult] {
         return  try!
             NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-                .matches(in: string, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, string.characters.count))
+                .matches(in: string, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, string.count))
     }
     
     public class func findIntersection(_ ranges: [NSRange], withRange range: NSRange) -> [NSRange?] {

--- a/AKMaskFieldExample/AppDelegate.swift
+++ b/AKMaskFieldExample/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
* Updated deprecated characters iteration and count
* AKMaskFieldBlockCharacter pattern and character doesn't need to be
implicitly unwrapped